### PR TITLE
Increase scraper failure tolerance

### DIFF
--- a/Scripts/torrent_dw_films_scraper.py
+++ b/Scripts/torrent_dw_films_scraper.py
@@ -420,7 +420,7 @@ def save_to_db(movie_data):
         return False
 
 
-def scrape_movies(start_id=None, end_id=35000, max_consecutive_failures=10, resume=True):
+def scrape_movies(start_id=None, end_id=35000, max_consecutive_failures=100, resume=True):
     """Itera sobre los IDs de las películas y extrae los datos."""
     clear_stop_request()
 

--- a/Scripts/torrent_dw_series_scraper.py
+++ b/Scripts/torrent_dw_series_scraper.py
@@ -566,7 +566,7 @@ def insert_data(db_conn, series_title, season_number, quality, episodes):
         return 0
 
 
-def scrape_series(start_id=None, max_consecutive_failures=10, resume=True):
+def scrape_series(start_id=None, max_consecutive_failures=100, resume=True):
     """Itera sobre los IDs de las series y extrae los datos."""
     clear_stop_request()
 


### PR DESCRIPTION
## Summary
- raise the default consecutive failure limit for the series scraper to 100
- raise the default consecutive failure limit for the movies scraper to 100

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e362391244832895d850538ac89f95